### PR TITLE
Improve Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,13 +6,14 @@ CFLAGS += -D'VERSION="${VERSION}"'
 -include sdk/Makefile.mk
 
 .PHONY: all
-all: sdk
-	@$(MAKE) -s debug
+all: debug
 
 .PHONY: sdk
-sdk:
-	@if [ ! -f $(SDK_DIR)/Makefile.mk ]; then echo "Initializing Git submodule 'sdk'..."; git submodule update --init sdk; fi
+sdk: sdk/Makefile.mk
 
 .PHONY: update
-update: sdk
-	@echo "Updating Git submodule 'sdk'..."; git submodule update --remote --merge sdk
+update:
+	@git submodule update --remote --merge sdk
+
+sdk/Makefile.mk:
+	@git submodule update --init sdk


### PR DESCRIPTION
Make automatically builds missing includes and reevaluates source
Makefile. This is GNU extension and won't work anywhere else but
-include is the same deal in this case so Makefile is already GNU
specific.