### PR TITLE
Add .vscode init

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,3 +17,4 @@ update:
 
 sdk/Makefile.mk:
 	@git submodule update --init sdk
+	@git submodule update --init .vscode


### PR DESCRIPTION
When I clone with git clone (not bcf), then the .vscode folder does not update/init when i type `make`. This should load the files so I can use VSCode ctrl+shift+b after that.